### PR TITLE
AppleII support and more features added

### DIFF
--- a/ArduinoFDC.h
+++ b/ArduinoFDC.h
@@ -34,6 +34,18 @@
 #define S_VERIFY     8  // Verify after write failed
 #define S_READONLY   9  // Attempt to write to a write-protected disk
 
+#define MFM 0   // MFM Modulation
+#define WOZ 1   // Apple][ GCR ....  disable WOZ if not defineds
+
+#define NIBBLES  // include sipport for nibbles read
+
+#if defined(__AVR_ATmega2560__)
+//#define BUFF_SIZE 7168
+#define BUFF_SIZE 0x1a00
+#else
+#define BUFF_SIZE 515
+#endif
+
 class ArduinoFDCClass
 {
  public:
@@ -43,7 +55,11 @@ class ArduinoFDCClass
     DT_5_DDonHD, // 5.25" double density disk in high density drive (360 KB)
     DT_5_HD,     // 5.25" high density (1.2 MB)
     DT_3_DD,     // 3.5"  double density (720 KB)
-    DT_3_HD      // 3.5"  high density (1.44 MB)
+    DT_3_HD,      // 3.5"  high density (1.44 MB)
+    DT_5_RX50,    // 5.25" RX50
+#ifdef WOZ
+    DT_5_WOZ      // 5.25" Apple][
+#endif
   };
 
   enum DensityPinMode {
@@ -81,8 +97,17 @@ class ArduinoFDCClass
   // get number of tracks for the currently selected drive
   byte numTracks() const;
 
+  // get number of heads for the currently selected drive
+  byte numHeads() const;
+
   // get number of sectors for the currently selected drive
   byte numSectors() const;
+
+  // get modulation
+  byte moduLation() const;
+
+  // added: option to modifay drive geometry
+  void patchGeometry(int tracks,int sectors,int trackSpacing);
 
   // set the density pin mode for the currently selected drive
   void setDensityPinMode(enum DensityPinMode mode);
@@ -93,7 +118,10 @@ class ArduinoFDCClass
   //            read will be in buffer[1..512] (NOT: 0..511!)
   // See error codes above for possible return values
   byte readSector(byte track, byte side, byte sector, byte *buffer);
-
+  
+#ifdef NIBBLES
+  byte readNibbles(byte track, byte side, byte mode, int delay, byte*buffer);
+#endif
   // Write a sector to disk,
   // buffer MUST have a size of at least 516 bytes.
   // IMPORTANT: The 512 bytes of sector data to be written

--- a/NEWFEATURES.txt
+++ b/NEWFEATURES.txt
@@ -1,0 +1,50 @@
+## New Features
+
+I added a few new features to David's excellent code, demonstratimg the power of those AVR Arduinos.
+
+As other devices with more memory, the Nano can still do this and, morover, is fully 5V compliant! 
+
+
+1.  Support for AppleII floppies
+
+    Reading GCR formatted floppies is now supported, formattimg and writing is to be done.
+    Images read use phisical sector order. Interleaving is required for use of images  in Mame etc.
+
+    Select disk type 6 in  monitor ('t 6').
+
+2.  Support for DD/SS floppies, e.g. DEC RX50
+
+    Select with 't 5' 
+
+3.  Monitor command to temporarily modify disk geometry
+
+    'g t,s[,ts]'  max tracks, sectors, track spacing (1/2)
+
+4.  Monitor command to read low level nibble/flux  data
+
+    'n t,d,m'  track, delay from index hole/ms, mode
+
+    mode: 
+    1  Read nibble data with no wait
+    2  Read flux data (cycles between pulses)
+    3  Read nibbles after delay and waiting for GCR sector header
+    4  Read nibbles after delay and waiting for GCR data header
+
+5.  Caching for disk reads, nibble data
+
+    Buffer size increase to 6656 bytes (1 nibble track) on Atmega MEGA
+
+
+Code is "work in progess" and was tested on MEGA. Should work on Nano as well.
+
+New features may be disabled by uncommenting defines for NIBBLES and GCR. 
+
+Open issues: 
+GCR Reading hangs on none GCR disks, or if head is stuck on track >35.
+"motor on" from monitor does not work.
+XModem works fine with TeraTerm, but fails with minicom.
+
+Please feel free to contact me for questions/suggestions.
+
+Detlef Clawin
+dclawin@dctronic.de

--- a/readNibbles.h
+++ b/readNibbles.h
@@ -1,0 +1,97 @@
+
+byte ArduinoFDCClass::readNibbles(byte track, byte side, byte mode, int read_delay, byte *buffer)
+{
+  byte res = S_OK;
+  byte driveType = m_driveType[m_currentDrive];
+
+#ifdef DEBUG
+pinMode(LED_BUILTIN, OUTPUT);
+digitalWrite(LED_BUILTIN,LOW);
+#endif
+  // do some sanity checks
+  if( !m_initialized )
+    return S_NOTINIT;
+  else if( track>=geometry[driveType].numTracks || side>1 )
+    return S_NOHEADER;
+
+  // if motor is not running then turn it on now
+  bool turnMotorOff = false;
+  if( !motorRunning() )
+    {
+      turnMotorOff = true;
+      motorOn();
+    }
+
+  // assert DRIVE_SELECT
+  driveSelect(LOW);
+  // search track 
+  interrupts();
+  step_to_track0(); 
+  step_tracks(driveType,track);  // relative stepping, track byte here, isn't it integer ?
+  //noInterrupts(); // don 10 lines later
+
+  // get MFM bit length (in processor cycles, motor must be running for this)
+  byte bitLength = getBitLength();
+
+  res = wait_index_hole();
+	  
+    if( bitLength==0 )
+    res = S_NOTREADY;
+  else
+    {
+      // wait delay ms
+      delay(read_delay);
+      // set up timer
+      TCCRA = 0;
+      TCCRB = bit(CS0); // falling edge input capture, prescaler 1, no output compare
+      TCCRC = 0;
+      
+      // reading data is time sensitive so we can't have interrupts
+      noInterrupts();
+
+      // find the requested sector
+      // res = find_sector(driveType, bitLength, track, side, sector);
+      
+      // if we found the sector then read the data
+          // wait for data sync mark and read data
+          //res= read_data_gcr(bitLength, buffer, 5150, false) ;
+ #ifdef try_flux  // this is buggy
+       short int i;
+       i=0;
+       while ( i < BUFF_SIZE ) {
+       while ( ICF == TIFR) {};
+       buffer[i++] =TIFR-ICF ;
+       ICF = TIFR;
+       }
+       Serial.print("flux collected: ");
+       Serial.print(buffer[0],HEX);
+       Serial.println(buffer[1],HEX);
+       Serial.println(buffer[2],HEX);
+#else
+            Serial.print("readNibbles, scalling read_data_gcr, mode,bitlen=");
+               Serial.println(mode);
+               Serial.println(bitLength);
+               Serial.flush();
+          res= read_data_gcr(bitLength, buffer, BUFF_SIZE, false, mode) ;
+          //res= read_data_gcr(bitLength, buffer, 512 , false, mode) ;
+               Serial.print("read_data return:"); 
+               Serial.println(res); 
+#endif
+      // interrupts are ok again
+      interrupts();
+
+      // stop timer
+      TCCRB = 0;
+    }
+
+  // de-assert DRIVE_SELECT
+   driveSelect(HIGH);
+
+  // if we turned the motor on then turn it off again
+  if( turnMotorOff ) {
+	 motorOff();
+  }
+
+  return res;
+}
+  

--- a/read_data_gcr.h
+++ b/read_data_gcr.h
@@ -1,0 +1,191 @@
+typedef unsigned char byte;
+
+//static byte read_data_gcr(byte bitlen, byte *buffer, unsigned int n, byte verify)
+static byte read_data_gcr(byte bitlen, byte *buffer, unsigned int n, byte verify, byte mode)
+// mode: 0  = read after header search  1: read nibble (no search), 2: flux
+{
+  // Parameter mode:
+  // 1: read mibbles without trigger
+  // 2: read flux
+  // 3  read nibbles for header
+  // 4  read ribbles for data
+
+  // iProblem: modes 3 and 4 hang if no header found, e.g.when head positioned beyond track 35
+  
+  // verifay not used any more
+
+	byte status;
+#ifndef readpulse
+   asm volatile 
+    (
+     // define READPULSE macro (wait for pulse)
+     // macro arguments: 
+     //         length: none => just wait for pulse, don't check         ( 9 cycles)
+     //                 1    => wait for pulse and jump if NOT short  (12/14 cycles)
+     //                 2    => wait for pulse and jump if NOT medium (14/16 cycles)
+     //                 3    => wait for pulse and jump if NOT long   (12/14 cycles)
+     //         dst:    label to jump to if DIFFERENT pulse found
+     // 
+     // on entry: r16 contains minimum length of medium pulse
+     //           r17 contains minimum length of long   pulse
+     //           r18 contains time of previous pulse
+     // on exit:  r18 is updated to the time of this pulse
+     //           r22 contains the pulse length in timer ticks (=processor cycles)     
+     // CLOBBERS: r19
+     ".macro READGCR length=0,dst=undefined\n"
+     "        sbis    TIFR, ICF\n"     // (1/2) skip next instruction if timer input capture seen
+     "        rjmp    .-4\n"           // (2)   wait more 
+     "        lds     r19, ICRL\n"     // (2)   get time of input capture (ICR1L, lower 8 bits only)
+     "        sbi     TIFR, ICF\n "    // (2)   clear input capture flag
+     "        mov     r22, r19\n"      // (1)   calculate time since previous capture...
+     "        sub     r22, r18\n"      // (1)   ...into r22
+     "        mov     r18, r19\n"      // (1)   set r18 to time of current capture
+     "  .if \\length == 1\n"           //       waiting for short pule?
+     "        cp      r22, r16\n"      // (1)   compare r22 to min medium pulse
+     "        brlo   .+2\n"            // (1/2) skip jump if less
+     "        jmp   \\dst\n"          // (3)   not the expected pulse => jump to dst
+     "  .else \n"
+     "    .if \\length == 2\n"         // waiting for medium pulse?
+     "        cp      r16, r22\n"      // (1)   min medium pulse < r22? => carry set if so
+     "        brcc    .+2\n"           // (1/2) skip next instruction if carry is clear
+     "        cp      r22, r17\n"      // (1)   r22 < min long pulse? => carry set if so
+     "        brcs   .+2\n"            // (1/2) skip jump if greater
+     "        jmp   \\dst\n"          // (3)   not the expected pulse => jump to dst
+     "    .else\n"
+     "      .if \\length == 3\n" 
+     "        cp      r22, r17\n"      // (1)   min long pulse < r22?
+     "        brsh   .+2\n"            // (1/2) skip jump if greater
+     "        jmp   \\dst\n"          // (3)   not the expected pulse => jump to dst
+     "      .endif\n"
+     "    .endif\n"
+     "  .endif\n"
+     ".endm\n"
+
+     // define STOREGCR macro for storing or verifying data bit 
+     // storing  data  : 5/14 cycles for "1", 4/13 cycles for "0"
+     ".macro STOREGCR data:req,done:req\n"
+     "        lsl     r20\n"           // (1)   shift received data
+     ".if \\data != 0\n"
+     "        ori     r20, 1\n"        // (1)   store "1" bit
+     ".endif\n"
+     "        dec     r21\n"           // (1)   decrement bit counter
+     "        brne    .+10\n"          // (1/2) skip if bit counter >0
+     "        st      Z+, r20\n"       // (2)   store received data byte
+     "        ldi     r21, 8\n"        // (1)   re-initialize bit counter
+     "        subi    r26, 1\n"        // (1)   subtract one from byte counter
+     "        sbci    r27, 0\n"        // (1) 
+     "        brmi    \\done\n"        // (1/2) done if byte counter<0
+     ".endm\n" );
+#endif
+   
+     asm volatile 
+    (
+     "        push r21\n"   //  this was experimental .... 
+     "        push r20\n"   //  save r21/r2o
+     "        cli\n"   // disable interrupts
+
+     // prepare for reading nibbles
+ //    "        mov         r16, %2\n"   // (1)   r16 = 3 * (MFM bit len) = minimum length of medium pulse
+ //    "        lsr         r16\n"       // (1)
+ //    "        add         r16, %2\n"   // (1)  r
+ //    "        add         r16, %2\n"   // (1)
+ //    "        mov         r17, r16\n"  // (1)   r17 = 5 * (MFM bit len) = minimum length of long pulse
+ //    "        add         r17, %2\n"   // (1) 
+ //    "        add         r17, %2\n"   // (1)
+     "        ldi	r16,96\n"   // set fixed limits
+     "        ldi       r17,160\n"
+ //  "        ldi         %0, 0\n"     // (1)   default return status is S_OK //  why did this work before &0=7
+ //  "        mov         r15,%0\n"   // (1)   initialize timer overflow counter
+     "        ldi         r19, 0\n"     // (1)   default return status is S_OK // 
+     "        mov         r15, r19\n"   // (1)   initialize timer overflow counter
+     "        mov         %0,r19\n"   // (1)  default return status is S_OK // 
+     "        READGCR     \n"   // preset r18 .etc, . required ?
+     "        sbi         TIFR, TOV\n" // (2)   reset timer overflow flag
+//
+//  select mode
+//     "       ldi r19,2\n"
+//     "       cp %3,r19 \n" //mode == 2, flux
+     "       cpi %3,2 \n" //mode == 2, flux
+     "       brne m1\n" 
+     "       rjmp floop\n" 
+//
+     "m1:    cpi %3,1 \n" //mode == 1, no sync, , leave somthing in status, ?
+     "       brne gsync\n"  // rest is mode 0,3 ... sync
+     "       rjmp grdo\n"  // 
+// expect remaining part of first sync mark (..0011111111 1101 0101 10101010 10010110 ff d5 aa 96 )
+     "gsync:  READGCR 3,gsync\n"     // (12) expect  001 so gehts 
+     "bffst:  ldi r21,7\n"   // start 
+     "bff:    READGCR 1,gsync\n"     // (14) expect 1 
+     "        dec r21\n"
+     "        brne bff \n"
+     "        READGCR   \n"     // 1101 wait for 1st bit of d5
+     "        cp      r17, r22\n"      // (1)   pulse length >= 3 bits
+     "        brlo    bffst\n"          // 001 found, go back waiting for 1111111
+     "        READGCR   1,gsync\n"     //  2nd
+     "        ldi   r21,3\n"     //  
+     "b3x01:  READGCR   2,gsync\n"     // 01 0101   3x 01
+     "        dec r21\n"
+     "        brne b3x01 \n"
+     "        READGCR   1,gsync\n"     // 10101010 1
+     "        ldi   r21,4\n"     // 4 x 01 01 01 01 
+     "b4x01:  READGCR   2,gsync\n"     //  
+     "        dec r21\n"
+     "        brne b4x01 \n"
+     "        cpi %3,3 \n" //mode == 4, data with praeamble
+     "        brne mo4\n" 
+     "mo3:    READGCR   3,gsync\n"     // 0010110 
+     "        READGCR   2,gsync\n"     // 0110 
+     "        READGCR   1,gsync\n"     // 10  ...  one bit bissing
+     "        rjmp      bit1\n"
+     "mo4:    READGCR   2,gsync\n"     // 1/0101101  d5 aa ad   data preamble
+     "        READGCR   2,gsync\n"     // 01101
+     "        READGCR   1,gsync\n"     // 101 
+     "        READGCR   2,gsync\n"     // 01
+     "bit1:   READGCR   \n"     // preload 1st bit of data, 0-bit in between preamble and data
+     "        ldi     r21, 8\n"        // init bit counter with 1 prestored bit
+     "        STOREGCR 1,grdone\n"      // (5/14) store "1" bit
+     "        rjmp  grdo\n"        // (1)   store "1" bit
+     "bc:     ldi     r21, 8\n"        // (1)   initialize bit counter (8 bits per byte)
+     // nibble read loop
+     "grdo:   READGCR\n"             // (9)   wait for pulse
+     "        cp      r22, r16\n"      // (1)   pulse length > 2 bits
+     "        brlo    grone\n"          // (1/2) jump if not
+     "        cp      r22, r17\n"      // (1)   pulse length >= 3 bits
+     "        brlo    grtwo\n"          // (1/2) jump if not
+     //  001-Pulse, or longer ..
+     "        STOREGCR 0,grdone\n"      // (5/14) store "1" bit
+     "        STOREGCR 0,grdone\n"      // (5/14) store "1" bit
+     "        STOREGCR 1,grdone\n"      // (5/14) store "1" bit
+     "        rjmp    grdo\n"            // (2)    back to start (still odd)
+
+     // jump target for relative conditional jumps in STOREGCR macro
+     "grdone:  rjmp    grend\n"
+     
+     // 2 bit pulse
+     "grtwo:  STOREGCR 0,grdone\n"      // 2 zeros
+     "        STOREGCR 1,grdone\n"
+     "        rjmp    grdo\n"            // (2)   back to start (now even)
+
+     // short pulse (01) => read "1", still odd
+     "grone:  STOREGCR 1,grdone\n"      // 1 zero 
+     "        rjmp    grdo\n"            // (2)    back to start (still odd)
+     
+     // loop for reading flux data
+     "floop:    READGCR\n"         // (9)   wait for pulse
+     "        st      Z+, r22\n"       // (2)   store received data byte
+     "        subi    r26, 1\n"        // (1)   subtract one from byte counter
+     "        sbci    r27, 0\n"        // (1)
+     "        brmi    grend\n"        // (1/2) done if byte counter<0
+     "        rjmp    floop\n"
+     //
+     "grend:  pop r20       \n"   // restore r20,21 (test)
+     "        pop r21       \n"   // 
+     "        sei       \n"   //enable interrups
+     : "=r"(status)                         // outputs
+     : "r"(verify), "r"(bitlen), "r"(mode),"x"(n-1), "z"(buffer)   // inputs  (x=r26/r27, z=r30/r31)
+     :  "r15", "r16", "r17", "r18", "r19", "r20", "r21", "r22");  // clobbers
+    //}
+     
+  return status;
+}
+


### PR DESCRIPTION
1.  Support for AppleII floppies

    Reading GCR formatted floppies is now supported, formattimg and writing is to be done. Images read use phisical sector order. Interleaving is required for use of images  in Mame etc.

    Select disk type 6 in  monitor ('t 6').

2.  Support for DD/SS floppies, e.g. DEC RX50

    Select with 't 5'

3.  Monitor command to temporarily modify disk geometry

    'g t,s[,ts]'  max tracks, sectors, track spacing (1/2)

4.  Monitor command to read low level nibble/flux  data

    'n t,d,m'  track, delay from index hole/ms, mode

    mode: 1  Read nibble data with no wait 2  Read flux data (cycles between pulses) 3  Read nibbles after delay and waiting for GCR sector header 4  Read nibbles after delay and waiting for GCR data header

5.  Caching for disk reads, nibble data

    Buffer size increase to 6656 bytes (1 nibble track) on Atmega MEGA