### PR TITLE
Modify to work with more disk formats

### DIFF
--- a/ArduinoFDC.h
+++ b/ArduinoFDC.h
@@ -43,7 +43,7 @@ class ArduinoFDCClass
     DT_5_DDonHD, // 5.25" double density disk in high density drive (360 KB)
     DT_5_HD,     // 5.25" high density (1.2 MB)
     DT_3_DD,     // 3.5"  double density (720 KB)
-    DT_3_HD      // 3.5"  high density (1.44 MB)
+    DT_3_HD     // 3.5"  high density (1.44 MB)
   };
 
   enum DensityPinMode {
@@ -91,6 +91,12 @@ class ArduinoFDCClass
 
   // get number of sectors for the currently selected drive
   byte numSectors() const;
+
+  // get sector size for the currently selected drive
+  word secSize() const;
+
+  // change drive parametrs on the fly. 0 value - left unchanged
+  void patchGeometry(byte heads, byte tracks, byte trackSpacing, byte numSector, word sectorSize);
 
   // set the density pin mode for the currently selected drive
   void setDensityPinMode(enum DensityPinMode mode);


### PR DESCRIPTION
Extend drive geometry by a sector size and allow to change drive geometry on the fly. It is good to work with non-PC disks and not need to create a new drive geometry for each obscure format.
This code allows to work with sector size 128, 256 and 512 bytes. I am not sure, if track format code working well, however reading and writing sector is OK.

It can ignore disk side mark on sector header search, because some old systems does not using it correctly. (optional feature by define IGNORE_SIDE_MARK)

Added defines to change header seek timing.